### PR TITLE
Merge tag 'android-9.0.0_r16' into lineage-16.0

### DIFF
--- a/cc/config/arm64_device.go
+++ b/cc/config/arm64_device.go
@@ -50,15 +50,12 @@ var (
 			"-mcpu=cortex-a53",
 		},
 		"cortex-a55": []string{
-			// The cortex-a55 target is not yet supported,
-			// so use cortex-a53.
-			"-mcpu=cortex-a53",
+			"-mcpu=cortex-a55",
 		},
 		"cortex-a75": []string{
-			// Use the cortex-a53 since it is similar to the little
+			// Use the cortex-a55 since it is similar to the little
 			// core (cortex-a55) and is sensitive to ordering.
-			// The cortex-a55 target is not yet supported.
-			"-mcpu=cortex-a53",
+			"-mcpu=cortex-a55",
 		},
 		"kryo": []string{
 			// Use the cortex-a57 cpu since some compilers

--- a/cc/config/arm_device.go
+++ b/cc/config/arm_device.go
@@ -98,7 +98,7 @@ var (
 			"-D__ARM_FEATURE_LPAE=1",
 		},
 		"cortex-a55": []string{
-			"-mcpu=cortex-a53",
+			"-mcpu=cortex-a55",
 			"-mfpu=neon-fp-armv8",
 			// Fake an ARM compiler flag as these processors support LPAE which GCC/clang
 			// don't advertise.
@@ -107,7 +107,7 @@ var (
 			"-D__ARM_FEATURE_LPAE=1",
 		},
 		"cortex-a75": []string{
-			"-mcpu=cortex-a53",
+			"-mcpu=cortex-a55",
 			"-mfpu=neon-fp-armv8",
 			// Fake an ARM compiler flag as these processors support LPAE which GCC/clang
 			// don't advertise.

--- a/cc/sabi.go
+++ b/cc/sabi.go
@@ -74,8 +74,13 @@ func (sabimod *sabi) flags(ctx ModuleContext, flags Flags) Flags {
 
 	// RSClang does not support recent mcpu option likes exynos-m2.
 	// So we need overriding mcpu option when we want to use it.
-	if ctx.Arch().CpuVariant == "exynos-m2" {
-		flags.ToolingCFlags = append(flags.ToolingCFlags, "-mcpu=cortex-a53")
+	mappedArch := map[string]string{
+		"exynos-m2":  "cortex-a53",
+		"cortex-a55": "cortex-a53",
+		"cortex-a75": "cortex-a57",
+	}
+	if arch, ok := mappedArch[ctx.Arch().CpuVariant]; ok {
+		flags.ToolingCFlags = append(flags.ToolingCFlags, "-mcpu="+arch)
 	}
 
 	return flags


### PR DESCRIPTION
Android 9.0.0 Release 16 (PQ1A.181105.017.A1)

* tag 'android-9.0.0_r16':
  Remove workaround for cortex-a55/a75
  Update ToolingCFlags overrides to include other new architectures
  Fix VNDK-Ext ABI check regression

Change-Id: I0792d0ba25239273ccd1842e014aa316ef8eba8c